### PR TITLE
link up outputpath cli arg

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "quorum-genesis-tool",
-  "version": "0.0.9",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "quorum-genesis-tool",
-      "version": "0.0.9",
+      "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "argon2": "^0.28.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quorum-genesis-tool",
-  "version": "0.0.9",
+  "version": "0.1.0",
   "description": "A utility that lets developers create genesis files and node (&account) keys from ConsenSys!",
   "main": "build/index.js",
   "repository": "git@github.com:ConsenSys/quorum-genesis-tool.git",

--- a/src/lib/networkGenerate.ts
+++ b/src/lib/networkGenerate.ts
@@ -10,8 +10,6 @@ import * as besuConfig from "./besuConfig";
 import { tesseraOutput } from "./tessera";
 import { createTesseraConfig } from "./tesseraConfig";
 
-const OUTPUT_BASE_DIR = "./output";
-
 async function generateNodeConfig(numNodes: number, nodeType: string, accountPassword: string, curve: CryptoCurve, outputDir: string): Promise<NodeKeys[]> {
   const nNodes = numNodes;
   const nodes: NodeKeys[] = [];
@@ -27,6 +25,7 @@ async function generateNodeConfig(numNodes: number, nodeType: string, accountPas
 
 export async function generateNetworkConfig(quorumConfig: QuorumConfig): Promise<string> {
   // Create a new root folder each time - dont destroy anything that existed
+  const OUTPUT_BASE_DIR = `${quorumConfig.outputPath}/output`;
   const ts: string = fileHandler.createTimestamp();
   const outputDir: string = OUTPUT_BASE_DIR + "/" + ts;
 


### PR DESCRIPTION
outputPath CLI arg was not linked up if selected so now when the option is provided it will be to the folder: /user/folder/selection/output or otherwise defaults to ./output in current directory

Signed-off-by: Eric Lin <eric.lin@consensys.net>