### PR TITLE
when no path specified outputting to /output/output fix

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "quorum-genesis-tool",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "quorum-genesis-tool",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "argon2": "^0.28.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quorum-genesis-tool",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A utility that lets developers create genesis files and node (&account) keys from ConsenSys!",
   "main": "build/index.js",
   "repository": "git@github.com:ConsenSys/quorum-genesis-tool.git",

--- a/src/lib/networkGenerate.ts
+++ b/src/lib/networkGenerate.ts
@@ -25,7 +25,7 @@ async function generateNodeConfig(numNodes: number, nodeType: string, accountPas
 
 export async function generateNetworkConfig(quorumConfig: QuorumConfig): Promise<string> {
   // Create a new root folder each time - dont destroy anything that existed
-  const OUTPUT_BASE_DIR = `${quorumConfig.outputPath}/output`;
+  const OUTPUT_BASE_DIR = `${quorumConfig.outputPath}`;
   const ts: string = fileHandler.createTimestamp();
   const outputDir: string = OUTPUT_BASE_DIR + "/" + ts;
 


### PR DESCRIPTION
Default unspecified directory was going to /output/output bug, now fixed so that when no output path is given it should just go to ./output 

Signed-off-by: Eric Lin <eric.lin@consensys.net>