### PR TITLE
feature: support custom balance allocation to nodes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -141,6 +141,12 @@ export async function main(): Promise<void> {
           default: false,
           describe: "Include quorum-dev-quickstart test accounts",
         },
+        genesisNodeAllocation: {
+          type: "string",
+          demandOption: true,
+          default: "1000000000000000000000000000",
+          describe: "Balance allocated to each nodes",
+        },
         alloc: {
           type: "string",
           demandOption: true,
@@ -181,6 +187,7 @@ export async function main(): Promise<void> {
       quickstartDevAccounts: args.quickstartDevAccounts,
       noOutputTimestamp: args.noOutputTimestamp,
       prefundedAccounts: args.alloc,
+      genesisNodeAllocation: args.genesisNodeAllocation,
     };
   } else {
     const qr = new QuestionRenderer(rootQuestion);

--- a/src/lib/genesisGenerate.ts
+++ b/src/lib/genesisGenerate.ts
@@ -80,7 +80,7 @@ export function createBesuGenesis(
   }
   node.forEach((account) => {
     besu.alloc[account.ethAccount.address] = {
-      balance: "1000000000000000000000000000",
+      balance: quorumConfig.genesisNodeAllocation,
     };
   });
 
@@ -153,7 +153,7 @@ export function createGoQuorumGenesis(
   }
   node.forEach((account) => {
     goquorum.alloc[account.ethAccount.address] = {
-      balance: "1000000000000000000000000000",
+      balance: quorumConfig.genesisNodeAllocation,
     };
   });
 

--- a/src/questions/commonQs.ts
+++ b/src/questions/commonQs.ts
@@ -10,6 +10,12 @@ export const quickstartDevAccountsQuestion: QuestionTree = {
   prompt: "Include quorum-dev-quickstart test accounts: [y/N]",
 };
 
+export const genesisNodeAllocationQuestion: QuestionTree = {
+  name: "genesisNodeAllocation",
+  prompt:
+    "Balance allocated to each nodes: (default 1000000000000000000000000000)",
+};
+
 export const prefundedAccountsQuestion: QuestionTree = {
   name: "prefundedAccounts",
   prompt:

--- a/src/questions/qbftQs.ts
+++ b/src/questions/qbftQs.ts
@@ -31,6 +31,16 @@ _prefundedAccountsQuestion.transformerValidator = allocStringValidator(
   "{}"
 );
 
+const _genesisNodeAllocationQuestion: QuestionTree = Object.assign(
+  {},
+  commonQs.genesisNodeAllocationQuestion
+);
+_genesisNodeAllocationQuestion.transformerValidator = stringValidator(
+  _genesisNodeAllocationQuestion,
+  _prefundedAccountsQuestion,
+  "1000000000000000000000000000"
+);
+
 
 const _quickstartDevAccountsQuestion: QuestionTree = Object.assign(
   {},
@@ -38,7 +48,7 @@ const _quickstartDevAccountsQuestion: QuestionTree = Object.assign(
 );
 _quickstartDevAccountsQuestion.transformerValidator = getYesNoValidator(
   _quickstartDevAccountsQuestion,
-  _prefundedAccountsQuestion,
+  _genesisNodeAllocationQuestion,
   "n"
 );
 

--- a/src/types/quorumConfig.ts
+++ b/src/types/quorumConfig.ts
@@ -24,4 +24,5 @@ export type QuorumConfig = {
   quickstartDevAccounts: boolean;
   noOutputTimestamp: boolean;
   prefundedAccounts: string;
+  genesisNodeAllocation: string;
 };

--- a/tests/lib/testConstants.ts
+++ b/tests/lib/testConstants.ts
@@ -25,6 +25,7 @@ export const TEST_QUORUM_CONFIG: QuorumConfig = {
   quickstartDevAccounts: false,
   noOutputTimestamp: false,
   prefundedAccounts: "{}",
+  genesisNodeAllocation: "100",
 };
 
 export const TEST_NODE = {


### PR DESCRIPTION
## Current State

Node balance value assigned in `genesis.json` is hardcoded to always be `1000000000000000000000000000`

```json
"alloc": {
    "0x11d3559cdfbdaf31cfce809567222e0aa686d6e1": {
      "balance": "1000000000000000000000000000"
    },
    "0x1b3c32173fa916d68460ca7fc902c279198db10f": {
      "balance": "1000000000000000000000000000"
    },
    "0xf0860e25455fcecc54b9a9d8f7a113c3fcbc26f8": {
      "balance": "1000000000000000000000000000"
    },
    "0x677a650e0e430028e028af1338a7e99c1cf796cf": {
      "balance": "1000000000000000000000000000"
    },
    "0xf7a2c90071bde5b192f72e46eb8596c01d47884e": {
      "balance": "1000000000000000000000000000"
    },
    "0x29eabbd71b43178e0eb3e1c431636b5ea0298376": {
      "balance": "1000000000000000000000000000"
    },
    "0x1b8f4cc25e76b0bbf84437d489a0a43382a7f286": {
      "balance": "1000000000000000000000000000"
    }
  }
```

## Change

To allow for more control over supply & balance split between nodes & `prefundedAccounts`, this PR
- Introduces a new cli option & new question
```
--genesisNodeAllocation


Balance allocated to each nodes: (default 1000000000000000000000000000)
```
- its value default to `1000000000000000000000000000` for backward compatibility