### PR TITLE
Feature: Add support for pre-deployed smart contracts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -151,7 +151,7 @@ export async function main(): Promise<void> {
           type: "string",
           demandOption: true,
           default: "{}",
-          describe: "JSON format of the prefunded accounts {'address': { balance: '100000'}}",
+          describe: "JSON format of the prefunded accounts {'address': { 'balance': '100000', 'code': '60808060405...', 'storage': { '0x0000000000000000000000000000000000000000000000000000000000000001': '0x000040' }}}",
         },
         noOutputTimestamp: {
           type: "boolean",

--- a/src/lib/genesisGenerate.ts
+++ b/src/lib/genesisGenerate.ts
@@ -92,6 +92,8 @@ export function createBesuGenesis(
     Object.entries(prefundedAccounts).forEach(([key, value]) => {
       besu.alloc[key] = {
         balance: value.balance,
+        code: value.code,
+        storage: value.storage,
       };
     });
   }
@@ -165,6 +167,8 @@ export function createGoQuorumGenesis(
     Object.entries(prefundedAccounts).forEach(([key, value]) => {
       goquorum.alloc[key] = {
         balance: value.balance,
+        code: value.code,
+        storage: value.storage,
       };
     });
   }

--- a/src/questions/commonQs.ts
+++ b/src/questions/commonQs.ts
@@ -19,7 +19,7 @@ export const genesisNodeAllocationQuestion: QuestionTree = {
 export const prefundedAccountsQuestion: QuestionTree = {
   name: "prefundedAccounts",
   prompt:
-    "Include JSON format of the prefunded account {'address': { 'balance': '100000'}}: (default {})",
+    "Include JSON format of the prefunded account {'address': { 'balance': '100000', 'code': '60808060405...', 'storage': { '0x0000000000000000000000000000000000000000000000000000000000000001': '0x000040' }}}: (default {})",
 };
 
 export const accountPasswordQuestion: QuestionTree = {

--- a/src/types/genesis.ts
+++ b/src/types/genesis.ts
@@ -43,6 +43,10 @@ export type GenesisConfig = {
 
 export type Alloc = {
   balance: string;
+  code?: string;
+  storage?: {
+    [id: string]: string;
+  };
   comment?: string;
   privateKey?: string;
 };

--- a/tests/lib/testConstants.ts
+++ b/tests/lib/testConstants.ts
@@ -24,7 +24,7 @@ export const TEST_QUORUM_CONFIG: QuorumConfig = {
   tesseraPassword: "",
   quickstartDevAccounts: false,
   noOutputTimestamp: false,
-  prefundedAccounts: "{}",
+  prefundedAccounts: '{"0x000000000000000000000000000000000000000A": {"balance": 1000, "code": "060680880", "storage": "0x000001"}}',
   genesisNodeAllocation: "100",
 };
 


### PR DESCRIPTION
The current version of `quorum-genesis-tool` only supports pre-funded accounts with balance where there is no way to pass code and storage for an account at the genesis.

Considering  that`quorum-genesis-tool` is mostly used in Besu's helm charts (although new version of Besu has an operator sub-command for generating genesis file) and without support for pre-deployed contracts, helm chart templates are needed to be modified, adding this support would save a lot of time and effort. 

- Add `code` and `storage` field in `Alloc` item of genesis config object